### PR TITLE
Intermediate cache clearing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,4 +27,4 @@ Suggests:
 VignetteBuilder: knitr
 License: file LICENSE
 LazyData: NA
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0

--- a/R/execution.R
+++ b/R/execution.R
@@ -109,7 +109,17 @@ Execute <- function(workflow
                 }
             }
             
-            #TODO: clear cached output in modules when not needed anymore
+            if (clearCache){
+                # Clear cached output in any upstream modules where all of its downstream 
+                # dependencies are complete
+                for (upstreamModule in upstreamModules) {
+                    if (workflow$hasCompletedAllDownstreamModules(upstreamModule)) {
+                        upstreamModule$clearOutputCache()
+                    }
+                }
+            }
+            
+            
         }
         modulesToExecute <- modulesToExecute[as.logical(lapply(modulesToExecute, is.Module))] # clears out NaNs when modules moved from modulesToExecute to modulesToExecute
     }

--- a/R/workflow_dag.R
+++ b/R/workflow_dag.R
@@ -356,6 +356,16 @@ DAGWorkflow <- R6::R6Class("DAGWorkflow"
                                         , "out"))
         }
         
+        , hasCompletedAllDownstreamModules = function(module) {
+            downstreamModules <- self$getDownstreamModules(module)
+            downstreamCompletedVec <- vapply(
+                downstreamModules
+                , function(m) {m$hasCompleted()}
+                , logical(1)
+            )
+            return(all(downstreamCompletedVec))
+        }
+        
         , getEndingModules = function() {
             endingModules <- list()
             

--- a/R/workflow_interface.R
+++ b/R/workflow_interface.R
@@ -15,6 +15,7 @@
 #'      \item{\code{getStartingModules()}}{Gets a list of modules that are the starting modules of a workflow.}
 #'      \item{\code{getDownstreamModules(module)}}{Gets modules downstream of \code{module} in a workflow.}
 #'      \item{\code{getUpstreamModules(module)}}{Gets modules upstream of \code{module} in a workflow.}
+#'      \item{\code{hasCompletedAllDownstreamModules(module)}}{Indicates if all modules downstream of \code{module} in a workflow have completed.}
 #'      \item{\code{initFromFile(filename)}}{Initializes this workflow from a save state stored in \code{filename}.}
 #'      \item{\code{removeConnection(connection)}}{Removes \code{connection}, an implementation instance of \code{ConnectionInterface}, to this workflow.}
 #'      \item{\code{removeModule(module)}}{Adds \code{module}, an implementation instance of \code{ModuleInterface}, to this workflow.}
@@ -64,6 +65,10 @@ WorkflowInterface <- R6::R6Class( "WorkflowInterface"
 
         , getUpstreamModules = function(module) {
             UpDraftSettings$errorLogger("getUpstreamModules not implemented in ", class(self)[1])    
+        }
+        
+        , hasCompletedAllDownstreamModules = function(module) {
+            UpDraftSettings$errorLogger("hasCompletedAllDownstreamModules not implemented in ", class(self)[1])
         }
         
         , removeConnection = function(connection) {

--- a/man/DAGWorkflow.Rd
+++ b/man/DAGWorkflow.Rd
@@ -75,6 +75,13 @@ Directed Acyclic Graph (DAG) workflow implementation
             \item{\bold{Returns}: list of downstream modules}
         }
     }
+    \item{\code{hasCompletedAllDownstreamModules(module)}}{
+        \itemize{
+            \item{Checks the completion of all downstream modules of \code{module}.}
+            \item{\bold{\code{module}}: valid implementation \code{ModuleInterface} obj or name of module that is present in a workflow.}
+            \item{\bold{Returns}: logical indicating all downstream modules are complete}
+        }
+    }
     \item{\code{getEndingModules()}}{
         \itemize{
             \item{Gets a list of ending modules in a workflow.}

--- a/man/LogStrackTrace.Rd
+++ b/man/LogStrackTrace.Rd
@@ -5,8 +5,8 @@
 \alias{LogStackTrace}
 \title{Log Stack Trace}
 \usage{
-LogStackTrace(moduleName, errorMessage, fileName = NULL, charLimit = 256,
-  objectLimit = 1e+05)
+LogStackTrace(moduleName, errorMessage, fileName = NULL,
+  charLimit = 256, objectLimit = 1e+05)
 }
 \arguments{
 \item{moduleName}{the name of the module that triggered the stack trace}

--- a/man/WorkflowInterface.Rd
+++ b/man/WorkflowInterface.Rd
@@ -25,6 +25,7 @@ Defines a contract of implementation for any workflow based class, i.e. a class 
      \item{\code{getStartingModules()}}{Gets a list of modules that are the starting modules of a workflow.}
      \item{\code{getDownstreamModules(module)}}{Gets modules downstream of \code{module} in a workflow.}
      \item{\code{getUpstreamModules(module)}}{Gets modules upstream of \code{module} in a workflow.}
+     \item{\code{hasCompletedAllDownstreamModules(module)}}{Indicates if all modules downstream of \code{module} in a workflow have completed.}
      \item{\code{initFromFile(filename)}}{Initializes this workflow from a save state stored in \code{filename}.}
      \item{\code{removeConnection(connection)}}{Removes \code{connection}, an implementation instance of \code{ConnectionInterface}, to this workflow.}
      \item{\code{removeModule(module)}}{Adds \code{module}, an implementation instance of \code{ModuleInterface}, to this workflow.}

--- a/tests/testthat/test_workflow_dag.R
+++ b/tests/testthat/test_workflow_dag.R
@@ -78,6 +78,10 @@ test_that("Testing DAGWorkflow Class constructor and obj methods run to completi
         TRUE
     })
     expect_true({
+        workflow$hasCompletedAllDownstreamModules('mod1')
+        TRUE
+    })
+    expect_true({
         workflow$getConnections('mod1', 'mod2')
         TRUE
     })
@@ -122,7 +126,7 @@ test_that("Testing DAGWorkflow Class Static initFromFile Method", {
     })
 })
 
-test_that("Testing DAGWorkflow obj methods error when appriopriate", {
+test_that("Testing DAGWorkflow obj methods error when appropriate", {
     workflow <- DAGWorkflow$new()
     connection <- DirectedConnection$new("conn", "mod1", "mod2", '...')
     mod1 <- PackageFunctionModule$new("mod1", "paste")


### PR DESCRIPTION
Addresses #12 

- Adds method `hasCompletedAllDownstreamModules` to `WorkflowInterface` and `DAGWorkflow` classes to check whether a given module's downstream modules have all completed.
- Adds intermediate cache removal to `Execute`. Upon completion of a module, it will evaluate `hasCompletedAllDownstreamModules` on all its upstream modules and remove the upstream module's cache if true. 